### PR TITLE
Markdown-parser error and layout-crazies

### DIFF
--- a/src/documents/karriar/index.html.jade
+++ b/src/documents/karriar/index.html.jade
@@ -20,16 +20,14 @@ row-fluid#career
   .row
     .col-md-6
       #opportunities
-      :markdown
-        Gillar du utmanande projekt, ny teknik och att jobba tillsammans med skickliga kollegor?
+        :markdown
+          Gillar du utmanande projekt, ny teknik och att jobba tillsammans med skickliga kollegor?
 
-      h2 Vi söker nya kollegor
-       :markdown
-         [Frontendutvecklare med UX](/karriar/frontend-och-ux)
+          ## Vi söker nya kollegor
+          [Frontendutvecklare med UX](/karriar/frontend-och-ux)
 
       .hidden-xs
         :markdown
-
           ## Vi älskar spontanansökningar
           Vi värderar egna intressen och unika personligheter högt, så vem du än är där ute, tveka inte att kontakta [Johanna Månsson Grahn](/medarbetare/johanna) eller [Christian Landgren](/medarbetare/christian).
 
@@ -128,12 +126,11 @@ row-fluid#career
         *OP5, Teamviewer, samtliga Microsoft-program. Brandväggar från Clavister och Mikrotik.*
 
     .col-md-6.showcase-3d
-      :markdown
-        ## Kolla in vårt kontor i 3D
-
-        <a href="https://my.matterport.com/show/?m=YNZtsQ339ux" target="_blank" title="Kolla in vårt kontor i 3D"><img src="/content/images/career/showcase_3d.png"></a>
-
-        <a href="https://my.matterport.com/show/?m=YNZtsQ339ux" target="_blank" title="Kolla in vårt kontor i 3D">Välkommen in och ta en rundtur i våra kontorslokaler!</a>
+      h2 Kolla in vårt kontor i 3D
+      <a href="https://my.matterport.com/show/?m=YNZtsQ339ux" target="_blank" title="Kolla in vårt kontor i 3D">
+        <img src="/content/images/career/showcase_3d.png">
+        Välkommen in och ta en rundtur i våra kontorslokaler!
+      </a>
 
     .col-md-6.visible-xs
       :markdown

--- a/src/documents/om-oss/index.html.jade
+++ b/src/documents/om-oss/index.html.jade
@@ -20,11 +20,18 @@ chevron: true
   .row
     .col-md-6
       :markdown
-        ##Kvalitet, innovation och effektivitet
+        ## Kvalitet, innovation och effektivitet
         Iteam är en teknikbyrå i Stockholm som erbjuder agil utveckling, rådgivning och IT-drift till små och medelstora företag inom media, juridik, HR och bygg. Vi erbjuder komplexa tekniklösningar i projektform med agila arbetssätt vilket borgar för kvalitet, innovation och effektivitet. Iteam startades 1995 och vi är ett helt personalägt bolag och har högsta kreditrating enligt UC och har Trippel-A (AAA) enligt Soliditet. [Läs mer]( http://www.soliditet.se/cms/ratingstatistik) om Soliditets AAA-rating och statistik.
 
-        ##Att utvecklas är lösningen
+        ## Att utvecklas är lösningen
         Vi jobbar alltid i nära samarbete med våra kunder. Vi står för den tekniska lösningen när det handlar om att skapa eller vidareutveckla ett befintligt företag eller tjänst. Målet, oavsett uppdrag, är att både kund och medarbetare kontinuerligt ska utvecklas och växa - både som individ och företag.
+
+        ### Omsättning [MSEK]
+        <canvas class="turnoverNumbers" width="400" height="200"></canvas>
+
+        ### Antal medarbetare
+        <canvas class="employeeNumbers" width="400" height="200"></canvas>
+        Källa: Bolagsverket, Creditsafe och [Allabolag](http://www.allabolag.se/5565516928/Iteam_Solutions_AB)
 
     .col-md-5.col-md-offset-1.map
       :markdown
@@ -36,41 +43,26 @@ chevron: true
         ### Ring oss
         Ring vårt växelnummer är 08-26 70 90 eller direkt till våra [medarbetare](/medarbetare).
 
-        ### Kolla in vårt kontor i 3D
-        <a href="https://my.matterport.com/show/?m=YNZtsQ339ux" target="_blank" title="Kolla in vårt kontor i 3D"><img src="/content/images/career/showcase_3d.png"></a>
-
-        <a href="https://my.matterport.com/show/?m=YNZtsQ339ux" target="_blank" title="Kolla in vårt kontor i 3D">Välkommen in och ta en rundtur i våra kontorslokaler!</a>
-
       if document.certifications
-        div.certifications
+        .certifications.row
           h3 Partners
           ul
             each image in document.certifications
               li
                 img.certification(src=image)
 
-  .row(about-view)
-
-    .row
-      .col-md-5
-        :markdown
-          ##Lite statistik om oss:
-
-    .row
-      .col-md-5
-        h3 Omsättning [MSEK]
-        canvas.turnoverNumbers(width=400,height=200)
-
-      .col-md-5.col-md-offset-2
-        h3 Antal medarbetare
-        canvas.employeeNumbers(width=400,height=200)
-        p Källa: Bolagsverket, Creditsafe, och <a href="http://www.allabolag.se/5565516928/Iteam_Solutions_AB" target="blank">Allabolag</a>
+      .row
+        h3 Kolla in vårt kontor i 3D
+        <a href="https://my.matterport.com/show/?m=YNZtsQ339ux" target="_blank" title="Kolla in vårt kontor i 3D">
+          <img src="/content/images/career/showcase_3d.png">
+          Välkommen in och ta en rundtur i våra kontorslokaler!
+        </a>
 
   .row
     :markdown
-      #### Organisationsnummer: <input value="556551-6928" onclick="this.select()"> | VAT: <input value="SE556551-692801"  onclick="this.select()">
+      #### Organisationsnummer: <input value="556551-6928" onclick="this.select()"> | VAT: <input value="SE556551-692801" onclick="this.select()">
 
-      #### Fakturor tar vi helst emot på epost. <a href="mailto:invoice@iteam.se">invoice@iteam.se</a>
+      #### Fakturor tar vi helst emot på epost. [invoice@iteam.se](mailto:invoice@iteam.se)
 
   section.row
     each doc in getCollection('tjanster').toJSON()


### PR DESCRIPTION
When the markdown parser for the jade-template parses headlines, there
needs to be a space between `#` and the headline. If not, it will print
it as is, as a normal paragraph.

Also, there where some layout issues on the `om oss` page. This should
fix that.
